### PR TITLE
Use baseVal to make mouse events compatible with jQuery 1.4.4

### DIFF
--- a/lib/world-map.js
+++ b/lib/world-map.js
@@ -366,7 +366,8 @@ jvm.WorldMap.prototype = {
        SVG handling, use with caution. */
     this.container.delegate("[class~='jvectormap-element']", 'mouseover mouseout', function(e){
       var path = this,
-          type = jvm.$(this).attr('class').indexOf('jvectormap-region') === -1 ? 'marker' : 'region',
+          baseVal = jvm.$(this).attr('class').baseVal ? jvm.$(this).attr('class').baseVal : jvm.$(this).attr('class'),
+          type = baseVal.indexOf('jvectormap-region') === -1 ? 'marker' : 'region',
           code = type == 'region' ? jvm.$(this).attr('data-code') : jvm.$(this).attr('data-index'),
           element = type == 'region' ? map.regions[code].element : map.markers[code].element,
           labelText = type == 'region' ? map.mapData.paths[code].name : (map.markers[code].config.name || ''),
@@ -403,7 +404,8 @@ jvm.WorldMap.prototype = {
        SVG handling, use with caution. */
     this.container.delegate("[class~='jvectormap-element']", 'mouseup', function(e){
       var path = this,
-          type = jvm.$(this).attr('class').indexOf('jvectormap-region') === -1 ? 'marker' : 'region',
+          baseVal = jvm.$(this).attr('class').baseVal ? jvm.$(this).attr('class').baseVal : jvm.$(this).attr('class'),
+          type = baseVal.indexOf('jvectormap-region') === -1 ? 'marker' : 'region',
           code = type == 'region' ? jvm.$(this).attr('data-code') : jvm.$(this).attr('data-index'),
           clickEvent = jvm.$.Event(type+'Click.jvectormap'),
           element = type == 'region' ? map.regions[code].element : map.markers[code].element;


### PR DESCRIPTION
jvm.$(this).attr('class').indexOf method doesn't exist in jQuery 1.4.4, use baseVal when available.
