### PR TITLE
Replace $ by jQuery in converter to avoid conflicts with other libraries...

### DIFF
--- a/converter/converter.py
+++ b/converter/converter.py
@@ -29,7 +29,7 @@ class Map:
 
   def getJSCode(self):
     map = {"paths": self.paths, "width": self.width, "height": self.height, "insets": self.insets, "projection": self.projection}
-    return "$.fn.vectorMap('addMap', '"+self.name+"_"+self.projection['type']+"_"+self.language+"',"+anyjson.serialize(map)+');'
+    return "jQuery.fn.vectorMap('addMap', '"+self.name+"_"+self.projection['type']+"_"+self.language+"',"+anyjson.serialize(map)+');'
 
 
 class Converter:


### PR DESCRIPTION
To avoid conflicts with other libraries, would be better IMHO to use 'jQuery' instead of '$' while building maps.
