### PR TITLE
Use a more standard filename while building the package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-jquery-jvectormap.min.js
+jquery.jvectormap.min.js

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ done
 
 if [ -z "$1" ]
   then
-    minified=jquery-jvectormap.min.js
+    minified=jquery.jvectormap.min.js
   else
     minified=$1
 fi


### PR DESCRIPTION
I think the package filename should be jquery.jvectormap.min.js, instead of jquery-jvectormap.min.js.
