### PR TITLE
Add an option to hide the zoom buttons

### DIFF
--- a/lib/world-map.js
+++ b/lib/world-map.js
@@ -116,7 +116,9 @@ jvm.WorldMap = function(params) {
   }
   this.bindElementEvents();
   this.createLabel();
-  this.bindZoomButtons();
+  if (this.params.zoomButtons) {
+    this.bindZoomButtons();
+  }
   this.createRegions();
   this.createMarkers(this.params.markers || {});
 
@@ -830,6 +832,7 @@ jvm.WorldMap.circumference = 6381372 * Math.PI * 2;
 jvm.WorldMap.defaultParams = {
   map: 'world_mill_en',
   backgroundColor: '#505050',
+  zoomButtons: true,
   zoomOnScroll: true,
   zoomMax: 8,
   zoomMin: 1,


### PR DESCRIPTION
I'd like to implement my own interface for zooming with a slider, so I do not want the default zoom buttons to be displayed. I've added a configuration option to disable them. They are displayed by default, as before.
