### PR TITLE
Make it possible to handle mousemove events externally on the higher level

### DIFF
--- a/lib/world-map.js
+++ b/lib/world-map.js
@@ -256,31 +256,31 @@ jvm.WorldMap.prototype = {
   },
 
   bindContainerEvents: function(){
-    var mouseDown = false,
+    var mouseMoveHandler,
         oldPageX,
         oldPageY,
         map = this;
 
-    this.container.mousemove(function(e){
-      if (mouseDown) {
-        map.transX -= (oldPageX - e.pageX) / map.scale;
-        map.transY -= (oldPageY - e.pageY) / map.scale;
+    mouseMoveHandler = function(e){
+      map.transX -= (oldPageX - e.pageX) / map.scale;
+      map.transY -= (oldPageY - e.pageY) / map.scale;
 
-        map.applyTransform();
+      map.applyTransform();
 
-        oldPageX = e.pageX;
-        oldPageY = e.pageY;
-      }
-      return false;
-    }).mousedown(function(e){
-      mouseDown = true;
       oldPageX = e.pageX;
       oldPageY = e.pageY;
+      return false;
+    };
+
+    this.container.mousedown(function(e){
+      oldPageX = e.pageX;
+      oldPageY = e.pageY;
+      map.container.bind('mousemove', mouseMoveHandler);
       return false;
     });
 
     jvm.$('body').mouseup(function(){
-      mouseDown = false;
+      map.container.unbind('mousemove', mouseMoveHandler);
     });
 
     if (this.params.zoomOnScroll) {


### PR DESCRIPTION
I'm placing the map in a resizable element, but when I drag the handle and move it over the map (trying to make it smaller), the `mousemove` handler stops propagation of the events to the higher level, so the "resizable" UI element can't resize it.

I'm not sure if it was intentional, but I can't think of a reason to block all `mousemove` events.

At first I solved it by moving the `return false` statement to the `if (mouseDown) { }` block, but then I changed it so that the function is not even bound when not moving the map.
