### PR TITLE
Smoother zooming out when resizing the map

### DIFF
--- a/lib/world-map.js
+++ b/lib/world-map.js
@@ -171,7 +171,7 @@ jvm.WorldMap.prototype = {
   },
 
   resize: function() {
-    var curBaseScale = this.baseScale;
+    var curBaseScale = this.baseScale, curScale = this.scale, zoomStep;
     if (this.width / this.height > this.defaultWidth / this.defaultHeight) {
       this.baseScale = this.height / this.defaultHeight;
       this.baseTransX = Math.abs(this.width - this.defaultWidth * this.baseScale) / (2 * this.baseScale);
@@ -180,8 +180,9 @@ jvm.WorldMap.prototype = {
       this.baseTransY = Math.abs(this.height - this.defaultHeight * this.baseScale) / (2 * this.baseScale);
     }
     this.scale *= this.baseScale / curBaseScale;
-    this.transX *= this.baseScale / curBaseScale;
-    this.transY *= this.baseScale / curBaseScale;
+    zoomStep = this.scale / curScale;
+    this.transX -= (zoomStep - 1) / this.scale * (this.width / 2);
+    this.transY -= (zoomStep - 1) / this.scale * (this.height / 2);
   },
 
   /**


### PR DESCRIPTION
When resizing the map, the viewport is currently moving to one size. That
means that if you have the map centered on some country, resize the map to
make it smaller, than resize it to the original size and you are centered
on a different country.

With this patch, it tries to keep the viewport at the same point, so that
resizing the map has little effect on what you see on the map.
