### PR TITLE
Unbind mouseup event from body in remove()

### DIFF
--- a/lib/world-map.js
+++ b/lib/world-map.js
@@ -920,6 +920,7 @@ jvm.WorldMap.prototype = {
     this.label.remove();
     this.container.remove();
     jvm.$(window).unbind('resize', this.onResize);
+    jvm.$('body').unbind('mouseup');
   }
 };
 


### PR DESCRIPTION
Without this change, the remove() function doesn't work properly, and the jvm.WorldMap object cannot be garbage collected.
