### PR TITLE
Fix shapely module import error in convert.py

### DIFF
--- a/converter/converter.py
+++ b/converter/converter.py
@@ -126,7 +126,7 @@ class Converter:
 
       if geometryType == ogr.wkbPolygon or geometryType == ogr.wkbMultiPolygon:
         geometry.TransformTo( self.spatialRef )
-        shapelyGeometry = shapely.wkb.loads( geometry.ExportToWkb() )
+        shapelyGeometry = shapely.geometry.base.geom_from_wkb( geometry.ExportToWkb() )
         if not shapelyGeometry.is_valid:
           #buffer to fix selfcrosses
           shapelyGeometry = shapelyGeometry.buffer(0, 1)


### PR DESCRIPTION
I was using the converter and persistently ran into this error:

```
Traceback (most recent call last):
  File "converter.py", line 295, in <module>
    converter.convert(args['output_file'])
  File "converter.py", line 143, in convert
    self.loadData()
  File "converter.py", line 88, in loadData
    self.loadDataSource( sourceConfig )
  File "converter.py", line 129, in loadDataSource
    shapelyGeometry = shapely.wkb.loads( geometry.ExportToWkb() )
AttributeError: 'module' object has no attribute 'wkb'
```

`shapely.wkb` was clearly not being found, and it was just a thin wrapper around `shapely.geometry.base`, so I swapped that in.
