### PR TITLE
Fixes for inverse projection example

### DIFF
--- a/tests/reverse-projection.html
+++ b/tests/reverse-projection.html
@@ -66,7 +66,7 @@
               latLng = map.pointToLatLng(x, y),
               targetCls = $(e.target).attr('class');
 
-          if (latLng && (!targetCls || (targetCls && $(e.target).attr('class').indexOf('jvectormap-marker') === -1))) {
+          if (latLng && (!targetCls || targetCls.indexOf('jvectormap-marker') === -1)) {
             markersCoords[markerIndex] = latLng;
             map.addMarker(markerIndex, {latLng: [latLng.lat, latLng.lng]});
             markerIndex += 1;


### PR DESCRIPTION
Firefox does not provide the mouse event properties offsetX and offsetY. This fix uses the map container's offsets instead.

This is basically the commit datag/jvectormap@33e45d119 of the original feature branch of "inverse projections". Also, this should resolve #195.
