### PR TITLE
Avoid memory leak by removing 'mouseup' handler

### DIFF
--- a/lib/world-map.js
+++ b/lib/world-map.js
@@ -279,9 +279,10 @@ jvm.WorldMap.prototype = {
       return false;
     });
 
-    jvm.$('body').mouseup(function(){
+    this.onMouseup = function(){
       mouseDown = false;
-    });
+    };
+    jvm.$('body').mouseup(this.onMouseup);
 
     if (this.params.zoomOnScroll) {
       this.container.mousewheel(function(event, delta, deltaX, deltaY) {
@@ -920,6 +921,7 @@ jvm.WorldMap.prototype = {
     this.label.remove();
     this.container.remove();
     jvm.$(window).unbind('resize', this.onResize);
+    jvm.$('body').unbind('mouseup', this.onMouseup);
   }
 };
 


### PR DESCRIPTION
If this handler is not removed, it causes WorldMap object to continue consuming memory on Chrome 31.0.
