### PR TITLE
jQuery is optional and adapters can be injected

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-
-files=( \
+skipJQueryArg="--skip-jquery"
+skipJQuery=0
+jQueryFiles=(\
   jquery-jvectormap.js \
   jquery-mousewheel.js \
+)
+
+files=( \
   lib/jvectormap.js \
   lib/abstract-element.js \
   lib/abstract-canvas-element.js \
@@ -32,6 +36,12 @@ files=( \
 baseDir=`dirname $0`
 
 counter=0
+while [ $counter -lt ${#jQueryFiles[@]} ]; do
+  jQueryFiles[$counter]="$baseDir/${jQueryFiles[$counter]}"
+  let counter=counter+1
+done
+
+counter=0
 while [ $counter -lt ${#files[@]} ]; do
   files[$counter]="$baseDir/${files[$counter]}"
   let counter=counter+1
@@ -47,6 +57,19 @@ fi
 if [ -a $minified ]
   then
     rm $minified
+fi
+
+for arg in "$@"
+do
+  if [ $arg = $skipJQueryArg ];
+  then
+    skipJQuery=1
+  fi
+done
+
+if [ $skipJQuery -eq 0 ];
+then
+  cat ${jQueryFiles[*]} >> $minified  
 fi
 
 cat ${files[*]} >> $minified

--- a/lib/jvectormap.js
+++ b/lib/jvectormap.js
@@ -96,4 +96,4 @@ var jvm = {
   }
 };
 
-jvm.$ = jQuery;
+jvm.$ = window['jQuery'] || {};


### PR DESCRIPTION
The object is injected so developers can write adapters to use any other library than jQuery.

Inddeed, I've developed a Mootools adapter that you could be interested in: https://github.com/SocialBro/jvectormap-adapter-mootools

The changes I made do not affect to the API so it's safe to merge

**Changes in source code**
By default, it uses jQuery if it's loaded, else it's expected you inject the object later

```
jvm.$ = window['jQuery'] || {};
```

**Changes in the build.sh script**
I've added a new param `--skip-jquery` in order exclude any jQuery file in the concatenation process. By default they are included:

```
./build.sh --skip-jquery
```
