### PR TITLE
Fixed converter.py (missing import and usage of viewport argument)

### DIFF
--- a/converter/converter.py
+++ b/converter/converter.py
@@ -95,7 +95,7 @@ class Converter:
     self.viewportRect = False
 
     if self.viewport:
-      layer.SetSpatialFilterRect( *sourceConfig.get('viewport') )
+      layer.SetSpatialFilterRect( *self.viewport )
       transformation = osr.CoordinateTransformation( layer.GetSpatialRef(), self.spatialRef )
       point1 = transformation.TransformPoint(self.viewport[0], self.viewport[1])
       point2 = transformation.TransformPoint(self.viewport[2], self.viewport[3])


### PR DESCRIPTION
With OSX (Mavericks) and python 2.7 (and shapely module 1.3.1) the converter.py wasn't running, because of a missing import.

Also, the usage of the "viewport" argument led to an error. There's a hotfix included in this pull request, also.
