### PR TITLE
Apply 'box-model: content-box' to map buttons

### DIFF
--- a/jquery-jvectormap.css
+++ b/jquery-jvectormap.css
@@ -27,6 +27,7 @@
     cursor: pointer;
     line-height: 10px;
     text-align: center;
+    box-sizing: content-box;
 }
 
 .jvectormap-zoomin, .jvectormap-zoomout {


### PR DESCRIPTION
A common practice in CSS reset files is to apply a box-sizing of 'border-box' to all selectors, but map buttons in jvectormap are broken unless they are set to 'content-box'.

This is a screenshot of a map with

````css
  * {
    box-sizing: border-box;
  }
````

in CSS:

![jvectormap-box-sizing-border-box](https://cloud.githubusercontent.com/assets/2857572/5426793/a3d7d9a4-833d-11e4-9e98-c05a2a26dc6a.png)

This commit adds

````css
  box-sizing: content-box;
````

to jquery-jvectormap.css to fix the buttons' appearance.