### PR TITLE
Adding semicolons at the end of assignment statements

### DIFF
--- a/src/abstract-canvas-element.js
+++ b/src/abstract-canvas-element.js
@@ -11,7 +11,7 @@ jvm.AbstractCanvasElement = function(container, width, height){
   this.rootElement = new jvm[this.classPrefix+'GroupElement']();
   this.node.appendChild( this.rootElement.node );
   this.container.appendChild(this.node);
-}
+};
 
 /**
  * Add element to the certain group inside of the canvas.
@@ -22,7 +22,7 @@ jvm.AbstractCanvasElement.prototype.add = function(element, group){
   group = group || this.rootElement;
   group.add(element);
   element.canvas = this;
-}
+};
 
 /**
  * Create path and add it to the canvas.

--- a/src/abstract-shape-element.js
+++ b/src/abstract-shape-element.js
@@ -59,4 +59,4 @@ jvm.AbstractShapeElement.mergeStyles = function(styles, newStyles){
       styles[key] = newStyles[key];
     }
   }
-}
+};

--- a/src/color-scale.js
+++ b/src/color-scale.js
@@ -1,6 +1,6 @@
 jvm.ColorScale = function(colors, normalizeFunction, minValue, maxValue) {
   jvm.ColorScale.parentClass.apply(this, arguments);
-}
+};
 
 jvm.inherits(jvm.ColorScale, jvm.NumericScale);
 

--- a/src/legend.js
+++ b/src/legend.js
@@ -24,7 +24,7 @@ jvm.Legend = function(params) {
   }
 
   this.render();
-}
+};
 
 jvm.Legend.prototype.render = function(){
   var ticks = this.series.scale.getTicks(),
@@ -80,4 +80,4 @@ jvm.Legend.prototype.render = function(){
     inner.append(tick);
   }
   inner.append( jvm.$('<div/>').css('clear', 'both') );
-}
+};

--- a/src/map-object.js
+++ b/src/map-object.js
@@ -13,7 +13,7 @@ jvm.MapObject.prototype.getLabelText = function(key){
     text = null;
   }
   return text;
-}
+};
 
 jvm.MapObject.prototype.getLabelOffsets = function(key){
   var offsets;
@@ -26,7 +26,7 @@ jvm.MapObject.prototype.getLabelOffsets = function(key){
     }
   }
   return offsets || [0, 0];
-}
+};
 
 /**
  * Set hovered state to the element. Hovered state means mouse cursor is over element. Styles will be updates respectively.

--- a/src/multimap.js
+++ b/src/multimap.js
@@ -136,4 +136,4 @@ jvm.MultiMap.defaultParams = {
   mapUrlByCode: function(code, multiMap){
     return 'jquery-jvectormap-data-'+code.toLowerCase()+'-'+multiMap.defaultProjection+'-en.js';
   }
-}
+};

--- a/src/svg-canvas-element.js
+++ b/src/svg-canvas-element.js
@@ -6,7 +6,7 @@ jvm.SVGCanvasElement = function(container, width, height){
   this.node.appendChild( this.defsElement.node );
 
   jvm.AbstractCanvasElement.apply(this, arguments);
-}
+};
 
 jvm.inherits(jvm.SVGCanvasElement, jvm.SVGElement);
 jvm.mixin(jvm.SVGCanvasElement, jvm.AbstractCanvasElement);

--- a/src/svg-element.js
+++ b/src/svg-element.js
@@ -8,7 +8,7 @@
 
 jvm.SVGElement = function(name, config){
   jvm.SVGElement.parentClass.apply(this, arguments);
-}
+};
 
 jvm.inherits(jvm.SVGElement, jvm.AbstractElement);
 

--- a/src/svg-group-element.js
+++ b/src/svg-group-element.js
@@ -1,6 +1,6 @@
 jvm.SVGGroupElement = function(){
   jvm.SVGGroupElement.parentClass.call(this, 'g');
-}
+};
 
 jvm.inherits(jvm.SVGGroupElement, jvm.SVGElement);
 

--- a/src/svg-path-element.js
+++ b/src/svg-path-element.js
@@ -1,6 +1,6 @@
 jvm.SVGPathElement = function(config, style){
   jvm.SVGPathElement.parentClass.call(this, 'path', config, style);
   this.node.setAttribute('fill-rule', 'evenodd');
-}
+};
 
 jvm.inherits(jvm.SVGPathElement, jvm.SVGShapeElement);

--- a/src/svg-text-element.js
+++ b/src/svg-text-element.js
@@ -1,6 +1,6 @@
 jvm.SVGTextElement = function(config, style){
   jvm.SVGTextElement.parentClass.call(this, 'text', config, style);
-}
+};
 
 jvm.inherits(jvm.SVGTextElement, jvm.SVGShapeElement);
 


### PR DESCRIPTION
Missing semicolons in jquery-vectormap-2.0.1.min.js were causing https://github.com/systemjs/builder to throw errors. Adding semicolons to the end of assignment statements fixed the issue.
