### PR TITLE
Use debounce function for resize event

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -147,7 +147,7 @@ jvm.Map = function(params) {
   if (this.params.bindTouchEvents) {
     if (('ontouchstart' in window) || (window.DocumentTouch && document instanceof DocumentTouch)) {
       this.bindContainerTouchEvents();
-    } else if (window.PointerEvent) {
+    } else if (window.MSGesture) {
       this.bindContainerPointerEvents();
     }
   }


### PR DESCRIPTION
On window resize is attached the map.updateSize() function thus resizing the window call this function multiple times. It would be great to implement a debounce function to be called once the resize event ended.