### PR TITLE
Fix a small bug where extend is undefined

### DIFF
--- a/src/data-series.js
+++ b/src/data-series.js
@@ -36,7 +36,7 @@ jvm.DataSeries = function(params, elements, map) {
   this.setValues(this.values);
 
   if (this.params.legend) {
-    this.legend = new jvm.Legend($.extend({
+    this.legend = new jvm.Legend(jvm.$.extend({
       map: this.map,
       series: this
     }, this.params.legend))


### PR DESCRIPTION
When $ is not a global variable, or when it's not jQuery, $.extend() may return an `undefined` error.