### PR TITLE
Inhibit drilldown if mapName is null

### DIFF
--- a/src/multimap.js
+++ b/src/multimap.js
@@ -58,6 +58,10 @@ jvm.MultiMap.prototype = {
         var multimap = e.data.scope,
             mapName = multimap.params.mapNameByCode(code, multimap);
 
+        if (mapName === null) {
+            return;
+        }
+
         if (!multimap.drillDownPromise || multimap.drillDownPromise.state() !== 'pending') {
           multimap.drillDown(mapName, code);
         }


### PR DESCRIPTION
I have some regions I need represented but don't want to drilldown to. This modification allows me to return null from mapNameByCode function, and the multimap won't  try to drill down to that region.