### PR TITLE
fix for setFocus fails with (lat, lng) of (0, 0)

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -687,7 +687,7 @@ jvm.Map.prototype = {
         config.animate
       );
     } else {
-      if (config.lat && config.lng) {
+      if (config.lat !== undefined && config.lng !== undefined) {
         point = this.latLngToPoint(config.lat, config.lng);
         config.x = this.transX - point.x / this.scale;
         config.y = this.transY - point.y / this.scale;


### PR DESCRIPTION
Calling `#setFocus` on the map object currently fails when passed a lat/lng pair of `(0,0)`. This fixes that.