### PR TITLE
Suggested fix for "jquery.jvectormap.js:1929 Uncaught TypeError: Cann…

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -736,11 +736,15 @@ jvm.Map.prototype = {
 
     if (jvm.$.isArray(keys)) {
       for (i = 0; i < keys.length; i++) {
-        this[type][keys[i]].element.setSelected(true);
+        if (this[type].hasOwnProperty(keys[i])) {
+          this[type][keys[i]].element.setSelected(true);
+        }
       }
     } else {
       for (i in keys) {
-        this[type][i].element.setSelected(!!keys[i]);
+        if (this[type].hasOwnProperty(i)) {
+          this[type][i].element.setSelected(!!keys[i]);
+        }
       }
     }
   },


### PR DESCRIPTION
…ot read property 'element' of undefined"

This error occurs when the data you hand over to the map as `selectedRegions` contains country short codes which the current map does not have. In our application e.g. our webservice always delivers data from all countries of the world, but we're using a map of Europe only. Diffing our data with the available countries in our chosen map would be painful.