### PR TITLE
.error and .load was deprecated in jQuery 3.0

### DIFF
--- a/src/jvectormap.js
+++ b/src/jvectormap.js
@@ -99,9 +99,9 @@ var jvm = {
     var deferred = new jvm.$.Deferred(),
         img = jvm.$('<img/>');
 
-    img.error(function(){
+    img.on('error', function(){
       deferred.reject();
-    }).load(function(){
+    }).on('load', function(){
       deferred.resolve(img);
     });
     img.attr('src', url);


### PR DESCRIPTION
https://api.jquery.com/error/ - deprecated and removed
https://api.jquery.com/load/ - was replaced, not handling event anymore