### PR TITLE
Added params for setFocus to have loose zoom on regions

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -637,6 +637,7 @@ jvm.Map.prototype = {
    * @param This method takes a configuration object as the single argument. The options passed to it are the following:
    * @param {Array} params.regions Array of region codes to zoom to.
    * @param {String} params.region Region code to zoom to.
+   * @param {Number} params.loose Sets the zoom to be loose for region zoom. Bigger numbers mean more zoomed out.
    * @param {Number} params.scale Map scale to set.
    * @param {Number} params.lat Latitude to set viewport to.
    * @param {Number} params.lng Longitude to set viewport to.
@@ -678,6 +679,12 @@ jvm.Map.prototype = {
             }
           }
         }
+      }
+      if (config.loose) {
+        bbox.x -= bbox.width * config.loose
+        bbox.y -= bbox.height * config.loose
+        bbox.width += bbox.width * config.loose * 2
+        bbox.height += bbox.height * config.loose * 2
       }
       return this.setScale(
         Math.min(this.width / bbox.width, this.height / bbox.height),


### PR DESCRIPTION
Hi. This is my first attempt to contribute to a project on github, so not sure if I've done the right thing. Anyway, I've added on option for setFocus so that zoom to region doesn't have to make the region fill the whole map area.